### PR TITLE
Added random suffix to bucket names to allow easy recreation.

### DIFF
--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -17,8 +17,13 @@
 locals {
   full_name      = "slo-${var.config.service_name}-${var.config.feature_name}-${var.config.slo_name}"
   pubsub_configs = [for e in var.config.exporters : e if lower(e.class) == "pubsub"]
+  suffix         = random_id.suffix.hex 
 }
-
+  
+resource "random_id" "suffix" {
+  byte_length = 2
+}
+  
 resource "google_service_account" "main" {
   account_id   = local.full_name
   project      = var.project_id
@@ -57,7 +62,7 @@ module "slo-cloud-function" {
   job_schedule                          = var.schedule
   job_name                              = local.full_name
   topic_name                            = local.full_name
-  bucket_name                           = local.full_name
+  bucket_name                           = "${local.full_name}-${local.suffix}"
   function_name                         = local.full_name
   function_description                  = var.config.slo_description
   function_entry_point                  = "main"


### PR DESCRIPTION
Bucket names are unique, so we append a random suffix to them in order to be able to destroy / recreate.