### PR TITLE
Allow custom service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terraform-google-slo
 
-This module deploys the [`slo-generator`](https://github.com/GoogleCloudPlatform/professional-services/tree/master/tools/slo-generator) in Cloud Functions in order to compute
-and export SLOs on a schedule.
+This module deploys the [`slo-generator`](https://github.com/GoogleCloudPlatform/professional-services/tree/master/tools/slo-generator)
+in Cloud Functions in order to compute and export SLOs on a schedule.
 
 ## Architecture
 

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -47,9 +47,11 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | exporters | SLO export destinations config | list | n/a | yes |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |
 | function\_name | Cloud Function name | string | `"slo-exporter"` | no |
+| grant\_iam\_roles | Grant IAM roles to created service accounts | string | `"true"` | no |
 | project\_id | Project id to create SLO infrastructure | string | n/a | yes |
 | pubsub\_topic\_name | Pub/Sub topic name | string | `"slo-export-topic"` | no |
 | region | Region for the App Engine app | string | `"us-east1"` | no |
+| service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Name of the service account to create | string | `"slo-exporter"` | no |
 
 ## Outputs

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -64,5 +64,6 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | function\_name | Cloud Function name |
 | project\_id | Project id |
 | pubsub\_topic\_name | Ingress PubSub topic to SLO pipeline |
+| service\_account\_email | Service account email used to run the Cloud Function |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/slo-pipeline/iam.tf
+++ b/modules/slo-pipeline/iam.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  service_account_email = var.service_account_email != "" ? var.service_account_email : google_service_account.main.email
+  service_account_email = var.service_account_email != "" ? var.service_account_email : google_service_account.main[0].email
 }
 
 resource "google_service_account" "main" {

--- a/modules/slo-pipeline/main.tf
+++ b/modules/slo-pipeline/main.tf
@@ -61,7 +61,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb   = var.function_memory
   project               = var.project_id
   region                = var.region
-  service_account_email = google_service_account.main.email
+  service_account_email = local.service_account_email
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.main.name
   runtime               = "python37"

--- a/modules/slo-pipeline/outputs.tf
+++ b/modules/slo-pipeline/outputs.tf
@@ -43,3 +43,8 @@ output "pubsub_topic_name" {
   description = "Ingress PubSub topic to SLO pipeline"
   value       = google_pubsub_topic.stream.name
 }
+
+output "service_account_email" {
+  description = "Service account email used to run the Cloud Function"
+  value       = local.service_account_email
+}

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -60,3 +60,13 @@ variable "service_account_name" {
   description = "Name of the service account to create"
   default     = "slo-exporter"
 }
+
+variable "service_account_email" {
+  description = "Service account email (optional)"
+  default     = ""
+}
+
+variable "grant_iam_roles" {
+  description = "Grant IAM roles to created service accounts"
+  default     = true
+}

--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -48,10 +48,12 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 |------|-------------|:----:|:-----:|:-----:|
 | config | SLO Configuration | object | n/a | yes |
 | error\_budget\_policy | Error budget policy config | object | `<list>` | no |
+| grant\_iam\_roles | Grant IAM roles to created service accounts | string | `"true"` | no |
 | labels | Labels to apply to all resources created | map | `<map>` | no |
 | project\_id | SLO project id | string | n/a | yes |
 | region | Region to deploy the Cloud Function in | string | `"us-east1"` | no |
 | schedule | Cron-like schedule for Cloud Scheduler | string | `"* * * * */1"` | no |
+| service\_account\_email | Service account email (optional) | string | `""` | no |
 
 ## Outputs
 

--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -17,7 +17,7 @@
 locals {
   full_name             = "slo-${var.config.service_name}-${var.config.feature_name}-${var.config.slo_name}"
   pubsub_configs        = [for e in var.config.exporters : e if lower(e.class) == "pubsub"]
-  service_account_email = var.service_account_email != "" ? var.service_account_email : google_service_account.main.email
+  service_account_email = var.service_account_email != "" ? var.service_account_email : google_service_account.main[0].email
 }
 
 resource "google_service_account" "main" {

--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -15,29 +15,31 @@
  */
 
 locals {
-  full_name      = "slo-${var.config.service_name}-${var.config.feature_name}-${var.config.slo_name}"
-  pubsub_configs = [for e in var.config.exporters : e if lower(e.class) == "pubsub"]
+  full_name             = "slo-${var.config.service_name}-${var.config.feature_name}-${var.config.slo_name}"
+  pubsub_configs        = [for e in var.config.exporters : e if lower(e.class) == "pubsub"]
+  service_account_email = var.service_account_email != "" ? var.service_account_email : google_service_account.main.email
 }
 
 resource "google_service_account" "main" {
+  count        = var.service_account_email != "" ? 0 : 1
   account_id   = local.full_name
   project      = var.project_id
   display_name = "Service account for SLO computations"
 }
 
 resource "google_project_iam_member" "stackdriver" {
-  count   = var.config.backend.class == "Stackdriver" ? 1 : 0
+  count   = var.grant_iam_roles && var.config.backend.class == "Stackdriver" ? 1 : 0
   project = var.config.backend.project_id
   role    = "roles/monitoring.viewer"
-  member  = "serviceAccount:${google_service_account.main.email}"
+  member  = "serviceAccount:${local.service_account_email}"
 }
 
 resource "google_pubsub_topic_iam_member" "pubsub" {
-  count   = length(local.pubsub_configs)
+  count   = var.grant_iam_roles ? length(local.pubsub_configs) : 0
   topic   = local.pubsub_configs[count.index].topic_name
   project = local.pubsub_configs[count.index].project_id
   role    = "roles/pubsub.publisher"
-  member  = "serviceAccount:${google_service_account.main.email}"
+  member  = "serviceAccount:${local.service_account_email}"
 }
 
 resource "local_file" "slo" {
@@ -65,6 +67,6 @@ module "slo-cloud-function" {
   function_available_memory_mb          = 128
   function_runtime                      = "python37"
   function_source_archive_bucket_labels = var.labels
-  function_service_account_email        = google_service_account.main.email
+  function_service_account_email        = local.service_account_email
   function_labels                       = var.labels
 }

--- a/modules/slo/outputs.tf
+++ b/modules/slo/outputs.tf
@@ -26,7 +26,7 @@ output "config" {
 
 output "service_account_email" {
   description = "Service account email used to run the Cloud Function"
-  value       = google_service_account.main.email
+  value       = local.service_account_email
 }
 
 output "scheduler_job_name" {

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -100,3 +100,13 @@ variable "error_budget_policy" {
     }
   ]
 }
+
+variable "service_account_email" {
+  description = "Service account email (optional)"
+  default     = ""
+}
+
+variable "grant_iam_roles" {
+  description = "Grant IAM roles to created service accounts"
+  default     = true
+}


### PR DESCRIPTION
Some users cannot grant IAM roles as part of the module (cross-project grants or no IAM admin role on the Terraform service account).
This allows:
* Setting a flag `grant_iam_roles` to `false` if the IAM roles should be granted outside the module
* Pass an existing `service_account_email` if the service account is already provisioned.