### PR TITLE
add location and storage_class on storage bucket and fix quoted variables

### DIFF
--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -44,7 +44,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | bucket\_name | Name of the bucket to create | string | n/a | yes |
-| exporters | SLO export destinations config | object | n/a | yes |
+| exporters | SLO export destinations config | list | n/a | yes |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |
 | function\_name | Cloud Function name | string | `"slo-exporter"` | no |
 | grant\_iam\_roles | Grant IAM roles to created service accounts | string | `"true"` | no |

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -44,7 +44,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | bucket\_name | Name of the bucket to create | string | n/a | yes |
-| exporters | SLO export destinations config | list | n/a | yes |
+| exporters | SLO export destinations config | object | n/a | yes |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |
 | function\_name | Cloud Function name | string | `"slo-exporter"` | no |
 | grant\_iam\_roles | Grant IAM roles to created service accounts | string | `"true"` | no |
@@ -53,6 +53,8 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | region | Region for the App Engine app | string | `"us-east1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Name of the service account to create | string | `"slo-exporter"` | no |
+| storage\_bucket\_location | The GCS location | string | `"US"` | no |
+| storage\_bucket\_storage\_class | The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE | string | `"STANDARD"` | no |
 
 ## Outputs
 

--- a/modules/slo-pipeline/main.tf
+++ b/modules/slo-pipeline/main.tf
@@ -44,6 +44,7 @@ resource "google_bigquery_dataset" "main" {
 resource "google_storage_bucket" "bucket" {
   name    = var.bucket_name
   project = var.project_id
+  region  = var.region
 }
 
 resource "google_storage_bucket_object" "main" {

--- a/modules/slo-pipeline/main.tf
+++ b/modules/slo-pipeline/main.tf
@@ -42,9 +42,10 @@ resource "google_bigquery_dataset" "main" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name    = var.bucket_name
-  project = var.project_id
-  region  = var.region
+  name          = var.bucket_name
+  project       = var.project_id
+  location      = var.storage_bucket_location
+  storage_class = var.storage_bucket_storage_class
 }
 
 resource "google_storage_bucket_object" "main" {

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -24,7 +24,7 @@ variable "bucket_name" {
 
 variable "exporters" {
   description = "SLO export destinations config"
-  type        = list(object({}))
+  type        = "list"
 
   # wait on https://github.com/hashicorp/terraform/issues/22449 to be merged
   # type = list(object({

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -24,7 +24,7 @@ variable "bucket_name" {
 
 variable "exporters" {
   description = "SLO export destinations config"
-  type        = "list"
+  type        = list()
 
   # wait on https://github.com/hashicorp/terraform/issues/22449 to be merged
   # type = list(object({

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -24,7 +24,7 @@ variable "bucket_name" {
 
 variable "exporters" {
   description = "SLO export destinations config"
-  type        = list()
+  type        = list(object({}))
 
   # wait on https://github.com/hashicorp/terraform/issues/22449 to be merged
   # type = list(object({
@@ -54,6 +54,16 @@ variable "function_memory" {
 variable "region" {
   description = "Region for the App Engine app"
   default     = "us-east1"
+}
+
+variable "storage_bucket_location" {
+  description = "The GCS location"
+  default     = "US"
+}
+
+variable "storage_bucket_storage_class" {
+  description = "The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE"
+  default     = "STANDARD"
 }
 
 variable "service_account_name" {

--- a/test/setup/README.md
+++ b/test/setup/README.md
@@ -1,0 +1,35 @@
+# Integration Testing
+
+Use this directory to create resources reflecting the same resource fixtures
+created for use by the CI environment CI integration test pipelines.  The intent
+of these resources is to run the integration tests locally as closely as
+possible to how they will run in the CI system.
+
+Once created, store the service account key content into the
+`SERVICE_ACCOUNT_JSON` environment variable. This reflects the same behavior
+as used in CI.
+
+For example:
+
+```bash
+terraform init
+terraform apply
+mkdir -p ~/.credentials
+terraform output sa_key | base64 --decode > ~/.credentials/cloud-storage-sa.json
+```
+
+Then, configure the environment (suggest using direnv) like so:
+
+```bash
+export SERVICE_ACCOUNT_JSON=$(cat ${HOME}/.credentials/cloud-storage-sa.json)
+export PROJECT_ID="cloud-storage-module"
+```
+
+With these variables set, change to the root of the module and execute the
+`make test_integration` task. This make target is the same that is executed
+by this module's CI pipeline during integration testing, and will run the
+integration tests from your machine.
+
+Alternatively, to run the integration tests directly from the Docker
+container used by the module's CI pipeline, perform the above steps and then
+run the `make test_integration_docker` target


### PR DESCRIPTION
Add a new variable on `resource.google_storage_bucket.bucket`, mapped to `region` variable of the `slo-pipeline` module, because by default the storage is created in US.