### PR TITLE
[WIP] Update main.tf

### DIFF
--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -38,7 +38,7 @@ resource "local_file" "error_budget_policy" {
 
 module "slo_cloud_function" {
   source  = "terraform-google-modules/scheduled-function/google"
-  version = "~> 1.2"
+  version = "~> 1.4"
 
   project_id                            = var.project_id
   region                                = var.region

--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -38,7 +38,7 @@ resource "local_file" "error_budget_policy" {
 
 module "slo_cloud_function" {
   source  = "terraform-google-modules/scheduled-function/google"
-  version = "~> 1.3"
+  version = "~> 1.4"
 
   project_id                            = var.project_id
   region                                = var.region

--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -38,7 +38,7 @@ resource "local_file" "error_budget_policy" {
 
 module "slo_cloud_function" {
   source  = "terraform-google-modules/scheduled-function/google"
-  version = "~> 1.4"
+  version = "~> 1.2"
 
   project_id                            = var.project_id
   region                                = var.region


### PR DESCRIPTION
I have this error when using terraform-google-slo and terraform-google-scheduled-function v1.3

```
Error: Inconsistent conditional result types

  on .terraform/modules/slo_generator.slo-hp-fr-availability.slo_cloud_function/outputs.tf line 23, in output "scheduler_job":
  23:   value       = var.scheduler_job == null ? google_cloud_scheduler_job.job : var.scheduler_job
    |----------------
    | google_cloud_scheduler_job.job is tuple with 1 element
    | var.scheduler_job is null

The true and false result expressions must have consistent types. The given
expressions are tuple and object, respectively.

```

It's ok if why use terraform-google-scheduled-function v1.4