### PR TITLE
BUGFIX - Bad value on default_table_expiration_ms (6 days and not 1 year)

### DIFF
--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -43,7 +43,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| dataset\_default\_table\_expiration\_ms | (Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year (86400000) | string | `"86400000"` | no |
+| dataset\_default\_table\_expiration\_ms | (Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year (31536000000) | string | `"31536000000"` | no |
 | exporters | SLO export destinations config | list | n/a | yes |
 | function\_bucket\_name | Name of the bucket to create to store the Cloud Function code | string | `"slo-pipeline"` | no |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -43,7 +43,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| dataset\_default\_table\_expiration\_ms | (Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year (31536000000) | string | `"31536000000"` | no |
+| dataset\_default\_table\_expiration\_ms | The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended) | string | `""` | no |
 | exporters | SLO export destinations config | list | n/a | yes |
 | function\_bucket\_name | Name of the bucket to create to store the Cloud Function code | string | `"slo-pipeline"` | no |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -43,6 +43,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| dataset\_default\_table\_expiration\_ms | (Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year (86400000) | string | `"86400000"` | no |
 | exporters | SLO export destinations config | list | n/a | yes |
 | function\_bucket\_name | Name of the bucket to create to store the Cloud Function code | string | `"slo-pipeline"` | no |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |

--- a/modules/slo-pipeline/main.tf
+++ b/modules/slo-pipeline/main.tf
@@ -52,7 +52,7 @@ resource "google_bigquery_dataset" "main" {
   location                    = lookup(local.bigquery_configs[count.index], "location", "EU")
   friendly_name               = "SLO Reports"
   description                 = "Table storing SLO reports from SLO reporting pipeline"
-  default_table_expiration_ms = 525600000 # 1 year
+  default_table_expiration_ms = var.dataset_default_table_expiration_ms
 }
 
 module "event_function" {

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -90,7 +90,7 @@ variable "function_source_directory" {
 
 variable "dataset_default_table_expiration_ms" {
   type        = string
-  description = "(Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year (86400000)"
+  description = "(Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year (31536000000)"
   default     = "31536000000"
 }
 

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -88,6 +88,12 @@ variable "function_source_directory" {
   default     = ""
 }
 
+variable "dataset_default_table_expiration_ms" {
+  type        = string
+  description = "(Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year (86400000)"
+  default     = "86400000"
+}
+
 variable "slo_generator_version" {
   description = "SLO generator library version"
   default     = "0.1.7"

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -91,7 +91,7 @@ variable "function_source_directory" {
 variable "dataset_default_table_expiration_ms" {
   type        = string
   description = "(Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year (86400000)"
-  default     = "86400000"
+  default     = "31536000000"
 }
 
 variable "slo_generator_version" {

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -90,8 +90,8 @@ variable "function_source_directory" {
 
 variable "dataset_default_table_expiration_ms" {
   type        = string
-  description = "(Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year"
-  default     = "31536000000"
+  description = "The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended)"
+  default     = ""
 }
 
 variable "slo_generator_version" {

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -90,7 +90,7 @@ variable "function_source_directory" {
 
 variable "dataset_default_table_expiration_ms" {
   type        = string
-  description = "(Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year (31536000000)"
+  description = "(Optional) The default lifetime of the slo table in the dataset, in milliseconds. Default is 1 year"
   default     = "31536000000"
 }
 


### PR DESCRIPTION
Hello,

on the module `slo-pipeline` in `main.tf` we can find an error in the TF resource `google_bigquery_dataset.main` on the attribute `default_table_expiration_ms`. 
The static value choose is bad because `525600000ms` is equal to 6 days only and not 365 days / 1 year ..

I have added a new variable dataset_default_table_expiration_ms with a default to `never`. Expiration table on a Dataset is not a sliding windows, so after 1 year all datas will be deleted, not only the datas older than one year..

Benjamin

![image](https://user-images.githubusercontent.com/16098346/76438391-3a843b00-63bb-11ea-96f1-3df06fa0b603.png)
