### PR TITLE
BUGFIX - Bad default value for dataset_default_table_expiration_ms

### DIFF
--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -43,7 +43,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| dataset\_default\_table\_expiration\_ms | The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended) | string | `""` | no |
+| dataset\_default\_table\_expiration\_ms | The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended) | string | `"null"` | no |
 | exporters | SLO export destinations config | list | n/a | yes |
 | function\_bucket\_name | Name of the bucket to create to store the Cloud Function code | string | `"slo-pipeline"` | no |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -91,7 +91,7 @@ variable "function_source_directory" {
 variable "dataset_default_table_expiration_ms" {
   type        = string
   description = "The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended)"
-  default     = ""
+  default     = null
 }
 
 variable "slo_generator_version" {


### PR DESCRIPTION
We have a bug with the default value of the variable `dataset_default_table_expiration_ms`: a number or `null` value is required, not a string like `""`.