### PR TITLE
Fix exporter bug

### DIFF
--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -46,11 +46,15 @@ variable "config" {
     slo_description = string
     service_name    = string
     feature_name    = string
-    exporters = list(object({
-      class      = string
-      project_id = string
-      topic_name = string
-    }))
+    exporters       = "list"
+    # wait on https://github.com/hashicorp/terraform/issues/22449 to be merged
+    # type = list(object({
+    #   class = string
+    #   project_id = string
+    #   dataset_id = string
+    #   table_id = string
+    #   topic_name = string
+    # }))
     backend = object({
       class       = string
       project_id  = string


### PR DESCRIPTION
Currently, only the PubSub exporter can be configured in the `slo` module. This is not the case in the `slo-pipeline` module that accepts all kinds of exporters. This opens up for more use cases to create exporters, such as BigQuery and SD Monitoring.