### PR TITLE
Release module

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+releaseType: terraform-module
+handleGHRelease: true

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.6.0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -22,22 +22,10 @@ provider "google-beta" {
   version = "~> 3.19"
 }
 
-resource "google_service_account" "slo" {
-  account_id = "test-slo"
-  project    = var.project_id
-}
-
-resource "google_service_account" "slo_pipeline" {
-  account_id = "test-slo-pipeline"
-  project    = var.project_id
-}
-
 module "slo-pipeline" {
-  source                     = "../../modules/slo-pipeline"
-  project_id                 = var.project_id
-  region                     = var.region
-  use_custom_service_account = true
-  service_account_email      = google_service_account.slo.email
+  source     = "../../modules/slo-pipeline"
+  project_id = var.project_id
+  region     = var.region
   exporters = [
     {
       class      = "Stackdriver"
@@ -55,13 +43,11 @@ module "slo-pipeline" {
 }
 
 module "slo" {
-  source                     = "../../modules/slo"
-  schedule                   = var.schedule
-  region                     = var.region
-  project_id                 = var.project_id
-  labels                     = var.labels
-  use_custom_service_account = true
-  service_account_email      = google_service_account.slo_pipeline.email
+  source     = "../../modules/slo"
+  schedule   = var.schedule
+  region     = var.region
+  project_id = var.project_id
+  labels     = var.labels
   config = {
     slo_name        = "pubsub-ack"
     slo_target      = "0.9"

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -15,13 +15,29 @@
  */
 
 provider "google" {
-  version = "~> 2.0"
+  version = "~> 3.19"
+}
+
+provider "google-beta" {
+  version = "~> 3.19"
+}
+
+resource "google_service_account" "slo" {
+  account_id = "test-slo"
+  project    = var.project_id
+}
+
+resource "google_service_account" "slo_pipeline" {
+  account_id = "test-slo-pipeline"
+  project    = var.project_id
 }
 
 module "slo-pipeline" {
-  source     = "../../modules/slo-pipeline"
-  project_id = var.project_id
-  region     = var.region
+  source                     = "../../modules/slo-pipeline"
+  project_id                 = var.project_id
+  region                     = var.region
+  use_custom_service_account = true
+  service_account_email      = google_service_account.slo.email
   exporters = [
     {
       class      = "Stackdriver"
@@ -39,11 +55,13 @@ module "slo-pipeline" {
 }
 
 module "slo" {
-  source     = "../../modules/slo"
-  schedule   = var.schedule
-  region     = var.region
-  project_id = var.project_id
-  labels     = var.labels
+  source                     = "../../modules/slo"
+  schedule                   = var.schedule
+  region                     = var.region
+  project_id                 = var.project_id
+  labels                     = var.labels
+  use_custom_service_account = true
+  service_account_email      = google_service_account.slo_pipeline.email
   config = {
     slo_name        = "pubsub-ack"
     slo_target      = "0.9"

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -43,7 +43,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| dataset\_default\_table\_expiration\_ms | The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended) | string | `"null"` | no |
+| dataset\_default\_table\_expiration\_ms | The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended) | number | `"-1"` | no |
 | exporters | SLO export destinations config | list | n/a | yes |
 | function\_bucket\_name | Name of the bucket to create to store the Cloud Function code | string | `"slo-pipeline"` | no |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |
@@ -55,7 +55,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | region | Region for the App Engine app | string | `"us-east1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Name of the service account to create | string | `"slo-pipeline"` | no |
-| slo\_generator\_version | SLO generator library version | string | `"0.1.7"` | no |
+| slo\_generator\_version | SLO generator library version | string | `"1.0.1"` | no |
 | storage\_bucket\_location | The GCS location | string | `"US"` | no |
 | storage\_bucket\_storage\_class | The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE | string | `"STANDARD"` | no |
 

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -44,7 +44,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | dataset\_default\_table\_expiration\_ms | The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended) | number | `"-1"` | no |
-| exporters | SLO export destinations config | list | n/a | yes |
+| exporters | SLO export destinations config | list(any) | n/a | yes |
 | function\_bucket\_name | Name of the bucket to create to store the Cloud Function code | string | `"slo-pipeline"` | no |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |
 | function\_name | Cloud Function name | string | `"slo-pipeline"` | no |
@@ -58,6 +58,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | slo\_generator\_version | SLO generator library version | string | `"1.0.1"` | no |
 | storage\_bucket\_location | The GCS location | string | `"US"` | no |
 | storage\_bucket\_storage\_class | The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE | string | `"STANDARD"` | no |
+| use\_custom\_service\_account | Use a custom service account (pass service_account_email if true) | bool | `"false"` | no |
 
 ## Outputs
 

--- a/modules/slo-pipeline/code/requirements.txt
+++ b/modules/slo-pipeline/code/requirements.txt
@@ -1,1 +1,0 @@
-slo_generator==1.0.0

--- a/modules/slo-pipeline/iam.tf
+++ b/modules/slo-pipeline/iam.tf
@@ -15,11 +15,11 @@
  */
 
 locals {
-  service_account_email = var.service_account_email != "" ? var.service_account_email : google_service_account.main[0].email
+  service_account_email = var.use_custom_service_account ? var.service_account_email : google_service_account.main[0].email
 }
 
 resource "google_service_account" "main" {
-  count        = var.service_account_email != "" ? 0 : 1
+  count        = var.use_custom_service_account ? 0 : 1
   account_id   = var.service_account_name
   project      = var.project_id
   display_name = "Service account for SLO export"

--- a/modules/slo-pipeline/iam.tf
+++ b/modules/slo-pipeline/iam.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  service_account_email = var.use_custom_service_account ? var.service_account_email : google_service_account.main[0].email
+  service_account_email = length(google_service_account.main) > 0 ? google_service_account.main[0].email : var.service_account_email
 }
 
 resource "google_service_account" "main" {

--- a/modules/slo-pipeline/main.tf
+++ b/modules/slo-pipeline/main.tf
@@ -23,6 +23,7 @@ locals {
       slo_generator_version = var.slo_generator_version
     }
   )
+  dataset_expiration = var.dataset_default_table_expiration_ms == -1 ? null : var.dataset_default_table_expiration_ms
 }
 
 resource "random_id" "suffix" {

--- a/modules/slo-pipeline/main.tf
+++ b/modules/slo-pipeline/main.tf
@@ -53,7 +53,7 @@ resource "google_bigquery_dataset" "main" {
   location                    = lookup(local.bigquery_configs[count.index], "location", "EU")
   friendly_name               = "SLO Reports"
   description                 = "Table storing SLO reports from SLO reporting pipeline"
-  default_table_expiration_ms = var.dataset_default_table_expiration_ms
+  default_table_expiration_ms = local.dataset_expiration
 }
 
 module "event_function" {

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -91,7 +91,7 @@ variable "function_source_directory" {
 variable "dataset_default_table_expiration_ms" {
   type        = number
   description = "The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended)"
-  default     = -1
+  default     = -1 # no expiration
 }
 
 variable "slo_generator_version" {

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -20,7 +20,7 @@ variable "project_id" {
 
 variable "exporters" {
   description = "SLO export destinations config"
-  type        = "list"
+  type        = list(any)
 
   # wait on https://github.com/hashicorp/terraform/issues/22449 to be merged
   # type = list(object({
@@ -70,6 +70,12 @@ variable "storage_bucket_storage_class" {
 variable "service_account_name" {
   description = "Name of the service account to create"
   default     = "slo-pipeline"
+}
+
+variable "use_custom_service_account" {
+  type        = bool
+  description = "Use a custom service account (pass service_account_email if true)"
+  default     = false
 }
 
 variable "service_account_email" {

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -89,12 +89,12 @@ variable "function_source_directory" {
 }
 
 variable "dataset_default_table_expiration_ms" {
-  type = number
+  type        = number
   description = "The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended)"
-  default     = null
+  default     = -1
 }
 
 variable "slo_generator_version" {
   description = "SLO generator library version"
-  default     = "0.1.7"
+  default     = "1.0.1"
 }

--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -63,6 +63,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | slo\_generator\_version | SLO generator library version | string | `"1.0.1"` | no |
 | time\_zone | The timezone to use in scheduler | string | `"Etc/UTC"` | no |
+| use\_custom\_service\_account | Use a custom service account (pass service_account_email if true) | bool | `"false"` | no |
 
 ## Outputs
 

--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -61,7 +61,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | region | Region to deploy the Cloud Function in | string | `"us-east1"` | no |
 | schedule | Cron-like schedule for Cloud Scheduler | string | `"* * * * */1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
-| slo\_generator\_version | SLO generator library version | string | `"0.1.7"` | no |
+| slo\_generator\_version | SLO generator library version | string | `"1.0.1"` | no |
 | time\_zone | The timezone to use in scheduler | string | `"Etc/UTC"` | no |
 
 ## Outputs

--- a/modules/slo/code/requirements.txt
+++ b/modules/slo/code/requirements.txt
@@ -1,1 +1,0 @@
-slo_generator==1.0.0

--- a/modules/slo/iam.tf
+++ b/modules/slo/iam.tf
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
+locals {
+  service_account_email = var.use_custom_service_account ? var.service_account_email : google_service_account.main[0].email
+}
+
 resource "google_service_account" "main" {
-  count        = var.service_account_email != "" ? 0 : 1
+  count        = var.use_custom_service_account ? 0 : 1
   account_id   = local.full_name
   project      = var.project_id
   display_name = "Service account for SLO computations"

--- a/modules/slo/iam.tf
+++ b/modules/slo/iam.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  service_account_email = var.use_custom_service_account ? var.service_account_email : google_service_account.main[0].email
+  service_account_email = length(google_service_account.main) > 0 ? google_service_account.main[0].email : var.service_account_email
 }
 
 resource "google_service_account" "main" {

--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -17,7 +17,6 @@
 locals {
   full_name                 = "slo-${var.config.service_name}-${var.config.feature_name}-${var.config.slo_name}"
   pubsub_configs            = [for e in var.config.exporters : e if lower(e.class) == "pubsub"]
-  service_account_email     = var.service_account_email != "" ? var.service_account_email : google_service_account.main[0].email
   function_source_directory = var.function_source_directory != "" ? var.function_source_directory : "${path.module}/code"
   suffix                    = random_id.suffix.hex
   requirements_txt = templatefile(

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -110,7 +110,14 @@ variable "error_budget_policy" {
   ]
 }
 
+variable "use_custom_service_account" {
+  type        = bool
+  description = "Use a custom service account (pass service_account_email if true)"
+  default     = false
+}
+
 variable "service_account_email" {
+  type        = string
   description = "Service account email (optional)"
   default     = ""
 }
@@ -133,7 +140,7 @@ variable "time_zone" {
 }
 
 variable "bucket_force_destroy" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "When deleting the GCS bucket containing the cloud function, delete all objects in the bucket first."
 }

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -35,7 +35,7 @@ variable "labels" {
 
 variable "slo_generator_version" {
   description = "SLO generator library version"
-  default     = "0.1.7"
+  default     = "1.0.1"
 }
 
 variable "config" {

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -29,7 +29,7 @@ variable "schedule" {
 
 variable "region" {
   description = "Region"
-  default     = "europe-west1"
+  default     = "us-east1"
 }
 
 variable "labels" {

--- a/test/fixtures/simple_example/variables.tf
+++ b/test/fixtures/simple_example/variables.tf
@@ -29,7 +29,7 @@ variable "schedule" {
 
 variable "region" {
   description = "Region"
-  default     = "us-east1"
+  default     = "europe-west1"
 }
 
 variable "labels" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 8.0"
 
   name              = "ci-slo"
   random_project_id = "true"

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -26,7 +26,7 @@ module "project" {
 
   activate_apis = [
     "appengine.googleapis.com",
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "cloudfunctions.googleapis.com",
     "cloudscheduler.googleapis.com",
     "logging.googleapis.com",

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.19"
 }
 
 provider "google-beta" {
-  version = "~> 2.12.0"
+  version = "~> 3.19"
 }


### PR DESCRIPTION
- [x] Fix default BigQuery table expiration as `null` was not compatible with the `number` type
- [x] Upgrade slo-generator default version to latest v1.0.1
- [x] Add release-please YAML config for automatic releases
- [x] Fix tests to make them pass
- [x] Fix deprecated variable types
- [x] Fix custom service account to not depend on dynamic values
- [x] Update `google` / `google-beta` providers versions