### PR TITLE
Share trigger accross SLO

### DIFF
--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -58,12 +58,14 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | labels | Labels to apply to all resources created | map | `<map>` | no |
 | message\_data | The data to send in the topic message. | string | `"dGVzdA=="` | no |
 | project\_id | SLO project id | string | n/a | yes |
+| pubsub\_trigger | The topic name of the pubsub (in the same project) to trigg the slo compute. | string | n/a | yes |
 | region | Region to deploy the Cloud Function in | string | `"us-east1"` | no |
-| schedule | Cron-like schedule for Cloud Scheduler | string | `"* * * * */1"` | no |
+| schedule | Cron-like schedule for Cloud Scheduler (ignored if use_custom_pubsub_trigger is true) | string | `"* * * * */1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Service account name (in case the generated one is too long) | string | `""` | no |
 | slo\_generator\_version | SLO generator library version | string | `"1.0.1"` | no |
 | time\_zone | The timezone to use in scheduler | string | `"Etc/UTC"` | no |
+| use\_custom\_pubsub\_trigger | Use a custom pubsub trigger (pass pubsub_trigger if true) | bool | `"false"` | no |
 | use\_custom\_service\_account | Use a custom service account (pass service_account_email if true) | bool | `"false"` | no |
 
 ## Outputs

--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -51,9 +51,9 @@ module "slo_cloud_function" {
 
   project_id                = var.project_id
   region                    = var.region
-  job_schedule              = var.schedule
-  job_name                  = local.full_name
-  topic_name                = local.full_name
+  job_schedule              = var.use_custom_pubsub_trigger ? null : var.schedule
+  job_name                  = var.use_custom_pubsub_trigger ? null : local.full_name
+  topic_name                = var.use_custom_pubsub_trigger ? var.pubsub_trigger : local.full_name
   bucket_name               = "${local.full_name}-${local.suffix}"
   bucket_force_destroy      = "true"
   function_name             = "${local.full_name}-${local.suffix}"

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -24,8 +24,19 @@ variable "region" {
 }
 
 variable "schedule" {
-  description = "Cron-like schedule for Cloud Scheduler"
+  description = "Cron-like schedule for Cloud Scheduler (ignored if use_custom_pubsub_trigger is true)"
   default     = "* * * * */1"
+}
+
+variable "use_custom_pubsub_trigger" {
+  type        = bool
+  description = "Use a custom pubsub trigger (pass pubsub_trigger if true)"
+  default     = false
+}
+
+variable "pubsub_trigger" {
+  description = "The topic name of the pubsub (in the same project) to trigg the slo compute."
+  type        = string
 }
 
 variable "labels" {


### PR DESCRIPTION
What I do not like in v0.1.0 is that the first stage of SLO are not shared; it's not very clean I think.

So I propose to split the first stage of the pipeline (the scheduler + pubsub) in another module.
Like the slo-exporter.

BTW: this module is not tested at all, it's juste a POC.