### PR TITLE
fix: Correct example `table_name` to `table_id`

### DIFF
--- a/examples/slo-generator/yaml_example/templates/exporters.yaml
+++ b/examples/slo-generator/yaml_example/templates/exporters.yaml
@@ -16,7 +16,7 @@ pipeline:
   - class: Bigquery
     project_id: ${project_id}
     dataset_id: slo_reports
-    table_name: report
+    table_id: report
 
   - class: Stackdriver
     project_id: ${stackdriver_host_project_id}


### PR DESCRIPTION
Fix #35 