### PR TITLE
fix: TF variable validation for backend so we can use other backends

### DIFF
--- a/modules/slo/iam.tf
+++ b/modules/slo/iam.tf
@@ -28,7 +28,7 @@ resource "google_service_account" "main" {
 
 resource "google_project_iam_member" "stackdriver" {
   count   = var.grant_iam_roles && var.config.backend.class == "Stackdriver" ? 1 : 0
-  project = var.config.backend.project_id
+  project = lookup(var.config.backend, "project_id", null)
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${local.sa_email}"
 }

--- a/modules/slo/iam.tf
+++ b/modules/slo/iam.tf
@@ -28,7 +28,7 @@ resource "google_service_account" "main" {
 
 resource "google_project_iam_member" "stackdriver" {
   count   = var.grant_iam_roles && var.config.backend.class == "Stackdriver" ? 1 : 0
-  project = lookup(var.config.backend, "project_id", var.project_id)
+  project = lookup(var.config.backend, "project_id", null)
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${local.sa_email}"
 }

--- a/modules/slo/iam.tf
+++ b/modules/slo/iam.tf
@@ -15,10 +15,10 @@
  */
 
 locals {
-  sa_name   = var.service_account_name != "" ? var.service_account_name : local.full_name
-  sa_email  = length(google_service_account.main) > 0 ? google_service_account.main[0].email : var.service_account_email
-  ssm_class = var.config.backend.class == "StackdriverServiceMonitoring"
-  sd_class  = var.config.backend.class == "Stackdriver"
+  sa_name            = var.service_account_name != "" ? var.service_account_name : local.full_name
+  sa_email           = length(google_service_account.main) > 0 ? google_service_account.main[0].email : var.service_account_email
+  ssm_class          = var.config.backend.class == "StackdriverServiceMonitoring"
+  sd_class           = var.config.backend.class == "Stackdriver"
   backend_project_id = lookup(var.config.backend, "project_id", null)
 }
 

--- a/modules/slo/iam.tf
+++ b/modules/slo/iam.tf
@@ -28,7 +28,7 @@ resource "google_service_account" "main" {
 
 resource "google_project_iam_member" "stackdriver" {
   count   = var.grant_iam_roles && var.config.backend.class == "Stackdriver" ? 1 : 0
-  project = lookup(var.config.backend, "project_id", null)
+  project = lookup(var.config.backend, "project_id", var.project_id)
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${local.sa_email}"
 }

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -57,7 +57,6 @@ variable "config" {
     # }))
     backend = object({
       class       = string
-      project_id  = string
       method      = string
       measurement = map(any)
     })

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -46,7 +46,15 @@ variable "config" {
     slo_description = string
     service_name    = string
     feature_name    = string
-    exporters       = list(any)
+    backend         = any
+    # wait on https://github.com/hashicorp/terraform/issues/19898 to get a
+    # resolution
+    # backend = object({
+    #   class       = string
+    #   method      = string
+    #   measurement = map(any)
+    # })
+    exporters = list(any)
     # wait on https://github.com/hashicorp/terraform/issues/22449 to be merged
     # type = list(object({
     #   class = string
@@ -55,11 +63,6 @@ variable "config" {
     #   table_id = string
     #   topic_name = string
     # }))
-    backend = object({
-      class       = string
-      method      = string
-      measurement = map(any)
-    })
   })
 }
 


### PR DESCRIPTION
Currently, the `project_id` field was mandatory in the `backend` section, but this does not make sense for any other type of backend than Cloud Monitoring or Cloud Service Monitoring.  We thus need an optional `project_id` argument in the `backend` object variable.

Since the [Terraform feature to have optional variable attributes](https://github.com/hashicorp/terraform/issues/19898) is not implemented yet, this removes the variable validation until further notice.

Fixes #42