### PR TITLE
fix: upgrade slo-generator version

### DIFF
--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -55,7 +55,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | region | Region for the App Engine app | string | `"us-east1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Name of the service account to create | string | `"slo-pipeline"` | no |
-| slo\_generator\_version | SLO generator library version | string | `"1.0.1"` | no |
+| slo\_generator\_version | SLO generator library version | string | `"1.1.2"` | no |
 | storage\_bucket\_location | The GCS location | string | `"US"` | no |
 | storage\_bucket\_storage\_class | The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE | string | `"STANDARD"` | no |
 | use\_custom\_service\_account | Use a custom service account (pass service_account_email if true) | bool | `"false"` | no |

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -102,5 +102,5 @@ variable "dataset_default_table_expiration_ms" {
 
 variable "slo_generator_version" {
   description = "SLO generator library version"
-  default     = "1.0.1"
+  default     = "1.1.2"
 }

--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -62,7 +62,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | schedule | Cron-like schedule for Cloud Scheduler | string | `"* * * * */1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Service account name (in case the generated one is too long) | string | `""` | no |
-| slo\_generator\_version | SLO generator library version | string | `"1.0.1"` | no |
+| slo\_generator\_version | SLO generator library version | string | `"1.1.2"` | no |
 | time\_zone | The timezone to use in scheduler | string | `"Etc/UTC"` | no |
 | use\_custom\_service\_account | Use a custom service account (pass service_account_email if true) | bool | `"false"` | no |
 

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -35,7 +35,7 @@ variable "labels" {
 
 variable "slo_generator_version" {
   description = "SLO generator library version"
-  default     = "1.0.1"
+  default     = "1.1.2"
 }
 
 variable "config" {


### PR DESCRIPTION
slo-generator had a broken dependency not pinned: this will upgrade existing installations to slo-generator 1.1.2 where it has been patched.

Fixes #45 