### PR TITLE
BREAKING CHANGE: Pass SLO config and Error Budget Policy paths instead of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,24 +80,11 @@ First, deploy the SLO export pipeline (shared module):
 
 ```hcl
 module "slo-pipeline" {
-  source                      = "terraform-google-modules/slo/google//modules/slo-pipeline"
-  function_name               = "slo-pipeline"
-  region                      = "us-east"
-  project_id                  = "test-project"
-  exporters = [
-    {
-      class      = "Stackdriver"
-      project_id = var.stackdriver_host_project_id
-    },
-    {
-      class                      = "Bigquery"
-      project_id                 = "test-project"
-      dataset_id                 = "slo"
-      table_id                   = "reports"
-      location                   = "EU"
-      delete_contents_on_destroy = true
-    }
-  ]
+  source         = "terraform-google-modules/slo/google//modules/slo-pipeline"
+  function_name  = "slo-pipeline"
+  region         = "us-east"
+  project_id     = "test-project"
+  exporters_path = <PATH_TO_EXPORTERS_CONFIG>
 }
 ```
 
@@ -106,33 +93,12 @@ Now, deploy an SLO definition:
 ### HCL format
 ```hcl
 module "slo" {
-  source     = "terraform-google-modules/slo/google//modules/slo"
-  schedule   = var.schedule
-  region     = var.region
-  project_id = var.project_id
-  labels     = var.labels
-  config = {
-    slo_name        = "pubsub-ack"
-    slo_target      = "0.9"
-    slo_description = "Acked Pub/Sub messages over total number of Pub/Sub messages"
-    service_name    = "svc"
-    feature_name    = "pubsub"
-    backend = {
-      class       = "Stackdriver"
-      method      = "good_bad_ratio"
-      project_id  = var.stackdriver_host_project_id
-      measurement = {
-        filter_good = "project=\"${module.slo-pipeline.project_id}\" AND metric.type=\"pubsub.googleapis.com/subscription/ack_message_count\""
-        filter_bad  = "project=\"${module.slo-pipeline.project_id}\" AND metric.type=\"pubsub.googleapis.com/subscription/num_outstanding_messages\""
-      }
-    }
-    exporters = [
-      {
-        class      = "Pubsub"
-        project_id = module.slo-pipeline.project_id
-        topic_name = module.slo-pipeline.pubsub_topic_name
-      }
-    ]
+  source      = "terraform-google-modules/slo/google//modules/slo"
+  schedule    = var.schedule
+  region      = var.region
+  project_id  = var.project_id
+  labels      = var.labels
+  config_path = <PATH_TO_SLO_CONFIG>
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -84,13 +84,12 @@ module "slo-pipeline" {
   function_name  = "slo-pipeline"
   region         = "us-east"
   project_id     = "test-project"
-  exporters_path = <PATH_TO_EXPORTERS_CONFIG>
+  exporters_path = var.exporters_path
 }
 ```
 
 Now, deploy an SLO definition:
 
-### HCL format
 ```hcl
 module "slo" {
   source      = "terraform-google-modules/slo/google//modules/slo"
@@ -98,25 +97,7 @@ module "slo" {
   region      = var.region
   project_id  = var.project_id
   labels      = var.labels
-  config_path = <PATH_TO_SLO_CONFIG>
-  }
-}
-```
-
-#### YAML format
-
-```hcl
-locals {
-  config = yamldecode(file("configs/my_slo_config.yaml"))
-}
-
-module "slo" {
-  source     = "terraform-google-modules/slo/google//modules/slo"
-  schedule   = var.schedule
-  region     = var.region
-  project_id = var.project_id
-  labels     = var.labels
-  config     = local.config
+  config_path = var.slo_config_path
 }
 ```
 A standard SRE practice is to write SLO definitions as YAML files, and follow DRY principles. See [`examples/slo-generator/yaml_example`](./examples/slo-generator/yaml_example) for an example of how to write re-usable YAML templates loaded into Terraform.

--- a/examples/slo-generator/simple_example/main.tf
+++ b/examples/slo-generator/simple_example/main.tf
@@ -30,7 +30,7 @@ locals {
   }
   vars_pipeline = {
     project_id                  = var.project_id
-    stackdriver_host_project_id = var.stackdriver_host_project_id 
+    stackdriver_host_project_id = var.stackdriver_host_project_id
   }
 }
 

--- a/examples/slo-generator/simple_example/templates/error_budget_policy.yaml
+++ b/examples/slo-generator/simple_example/templates/error_budget_policy.yaml
@@ -1,0 +1,43 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- error_budget_policy_step_name: 1h
+  measurement_window_seconds: 3600
+  alerting_burn_rate_threshold: 9
+  urgent_notification: true
+  overburned_consequence_message: Page to defend the SLO
+  achieved_consequence_message: Last hour on track
+
+- error_budget_policy_step_name: 12h
+  measurement_window_seconds: 43200
+  alerting_burn_rate_threshold: 3
+  urgent_notification: true
+  overburned_consequence_message: Page to defend the SLO
+  achieved_consequence_message: Last 12 hours on track
+
+- error_budget_policy_step_name: 7d
+  measurement_window_seconds: 604800
+  alerting_burn_rate_threshold: 1.5
+  urgent_notification: false
+  overburned_consequence_message: Dev team dedicates 25% of engineers to the
+    reliability backlog
+  achieved_consequence_message: Last week on track
+
+- error_budget_policy_step_name: 28d
+  measurement_window_seconds: 2419200
+  alerting_burn_rate_threshold: 1
+  urgent_notification: false
+  overburned_consequence_message: Freeze release, unless related to reliability
+    or security
+  achieved_consequence_message: Unfreeze release, per the agreed roll-out policy

--- a/examples/slo-generator/simple_example/templates/exporters_pipeline.yaml
+++ b/examples/slo-generator/simple_example/templates/exporters_pipeline.yaml
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-pipeline:
-  - class: Bigquery
-    project_id: ${project_id}
-    dataset_id: slo_reports
-    table_id: report
+- class: Bigquery
+  project_id: ${project_id}
+  dataset_id: slo_reports
+  table_id: report
 
-  - class: Stackdriver
-    project_id: ${stackdriver_host_project_id}
-
-slo:
-  - class: Pubsub
-    project_id: ${project_id}
-    topic_name: ${pubsub_topic_name}
+- class: Stackdriver
+  project_id: ${stackdriver_host_project_id}

--- a/examples/slo-generator/simple_example/templates/exporters_slo.yaml
+++ b/examples/slo-generator/simple_example/templates/exporters_slo.yaml
@@ -1,0 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- class: Pubsub
+  project_id: ${project_id}
+  topic_name: ${pubsub_topic_name}

--- a/examples/slo-generator/simple_example/templates/slo_pubsub_ack.yaml
+++ b/examples/slo-generator/simple_example/templates/slo_pubsub_ack.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+service_name:    generator
+feature_name:    pubsub
+slo_description: 99% of outstanding PubSub messages are acknowledged
+slo_name:        ack
+slo_target:      0.99
+backend:
+  class:         Stackdriver
+  project_id:    "${stackdriver_host_project_id}"
+  method:        good_bad_ratio
+  measurement:
+    filter_good: >
+      project="${project_id}"
+      metric.type="pubsub.googleapis.com/subscription/ack_message_count"
+      resource.type="pubsub_subscription"
+    filter_bad:  >
+      project="${project_id}"
+      metric.type="pubsub.googleapis.com/subscription/num_outstanding_messages"
+      resource.type="pubsub_subscription"

--- a/examples/slo-generator/yaml_example/main.tf
+++ b/examples/slo-generator/yaml_example/main.tf
@@ -23,10 +23,10 @@ provider "google-beta" {
 }
 
 locals {
-  error_budget_policy_path  = "${path.root}/templates/error_budget_policy.yaml"
-  exporters_path_pipeline   = "${path.root}/templates/exporters_pipeline.yaml"
-  exporters_path_slo        = "${path.root}/templates/exporters_slo.yaml"
-  slo_configs_paths         = tolist(fileset(path.root, "/templates/slo_*.yaml"))
+  error_budget_policy_path = "${path.root}/templates/error_budget_policy.yaml"
+  exporters_path_pipeline  = "${path.root}/templates/exporters_pipeline.yaml"
+  exporters_path_slo       = "${path.root}/templates/exporters_slo.yaml"
+  slo_configs_paths        = tolist(fileset(path.root, "/templates/slo_*.yaml"))
   exporters_vars_pipeline = {
     stackdriver_host_project_id = var.stackdriver_host_project_id
     project_id                  = var.project_id

--- a/examples/slo-generator/yaml_example/templates/error_budget_policy.yaml
+++ b/examples/slo-generator/yaml_example/templates/error_budget_policy.yaml
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- error_budget_policy_step_name: a.Last 1 hour
+- error_budget_policy_step_name: 1h
   measurement_window_seconds: 3600
   alerting_burn_rate_threshold: 9
   urgent_notification: true
   overburned_consequence_message: Page to defend the SLO
   achieved_consequence_message: Last hour on track
 
-- error_budget_policy_step_name: b.Last 12 hours
+- error_budget_policy_step_name: 12h
   measurement_window_seconds: 43200
   alerting_burn_rate_threshold: 3
   urgent_notification: true
   overburned_consequence_message: Page to defend the SLO
   achieved_consequence_message: Last 12 hours on track
 
-- error_budget_policy_step_name: c.Last 7 days
+- error_budget_policy_step_name: 7d
   measurement_window_seconds: 604800
   alerting_burn_rate_threshold: 1.5
   urgent_notification: false
@@ -34,7 +34,7 @@
     reliability backlog
   achieved_consequence_message: Last week on track
 
-- error_budget_policy_step_name: d.Last 28 days
+- error_budget_policy_step_name: 28d
   measurement_window_seconds: 2419200
   alerting_burn_rate_threshold: 1
   urgent_notification: false

--- a/examples/slo-generator/yaml_example/templates/exporters_pipeline.yaml
+++ b/examples/slo-generator/yaml_example/templates/exporters_pipeline.yaml
@@ -1,0 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- class: Bigquery
+  project_id: ${project_id}
+  dataset_id: slo_reports
+  table_id: report
+
+- class: Stackdriver
+  project_id: ${stackdriver_host_project_id}

--- a/examples/slo-generator/yaml_example/templates/exporters_slo.yaml
+++ b/examples/slo-generator/yaml_example/templates/exporters_slo.yaml
@@ -1,0 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- class: Pubsub
+  project_id: ${project_id}
+  topic_name: ${pubsub_topic_name}

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -45,7 +45,8 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 |------|-------------|:----:|:-----:|:-----:|
 | dataset\_create | Whether to create the BigQuery dataset | bool | `"true"` | no |
 | dataset\_default\_table\_expiration\_ms | The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended) | number | `"-1"` | no |
-| exporters | SLO export destinations config | list(any) | n/a | yes |
+| exporters\_path | SLO exporters config file path | string | n/a | yes |
+| exporters\_vars | Variables to dynamically replace in exporters config | map | n/a | yes |
 | function\_bucket\_name | Name of the bucket to create to store the Cloud Function code | string | `"slo-pipeline"` | no |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |
 | function\_name | Cloud Function name | string | `"slo-pipeline"` | no |
@@ -56,7 +57,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | region | Region for the App Engine app | string | `"us-east1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Name of the service account to create | string | `"slo-pipeline"` | no |
-| slo\_generator\_version | SLO generator library version | string | `"1.2.0"` | no |
+| slo\_generator\_version | SLO generator library version | string | `"1.3.0"` | no |
 | storage\_bucket\_location | The GCS location | string | `"US"` | no |
 | storage\_bucket\_storage\_class | The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE | string | `"STANDARD"` | no |
 | use\_custom\_service\_account | Use a custom service account (pass service_account_email if true) | bool | `"false"` | no |

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -46,7 +46,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | dataset\_create | Whether to create the BigQuery dataset | bool | `"true"` | no |
 | dataset\_default\_table\_expiration\_ms | The default lifetime of the slo table in the dataset, in milliseconds. Default is never (Recommended) | number | `"-1"` | no |
 | exporters\_path | SLO exporters config file path | string | n/a | yes |
-| exporters\_vars | Variables to dynamically replace in exporters config | map | n/a | yes |
+| exporters\_vars | Variables to dynamically replace in exporters config | map | `<map>` | no |
 | function\_bucket\_name | Name of the bucket to create to store the Cloud Function code | string | `"slo-pipeline"` | no |
 | function\_memory | Memory in MB for the Cloud Function (increases with no. of SLOs) | string | `"128"` | no |
 | function\_name | Cloud Function name | string | `"slo-pipeline"` | no |

--- a/modules/slo-pipeline/README.md
+++ b/modules/slo-pipeline/README.md
@@ -57,7 +57,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | region | Region for the App Engine app | string | `"us-east1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Name of the service account to create | string | `"slo-pipeline"` | no |
-| slo\_generator\_version | SLO generator library version | string | `"1.3.0"` | no |
+| slo\_generator\_version | SLO generator library version | string | `"1.3.1"` | no |
 | storage\_bucket\_location | The GCS location | string | `"US"` | no |
 | storage\_bucket\_storage\_class | The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE | string | `"STANDARD"` | no |
 | use\_custom\_service\_account | Use a custom service account (pass service_account_email if true) | bool | `"false"` | no |

--- a/modules/slo-pipeline/locals.tf
+++ b/modules/slo-pipeline/locals.tf
@@ -17,8 +17,7 @@
 locals {
   is_yaml          = length(regexall(".*yaml", var.exporters_path)) > 0
   exporters_tpl    = templatefile(var.exporters_path, var.exporters_vars)
-  config_map       = local.is_yaml ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
-  exporters        = local.config_map.exporters
+  exporters        = local.is_yaml ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
   bigquery_configs = [for e in local.exporters : e if lower(e.class) == "bigquery"]
   sd_configs       = [for e in local.exporters : e if lower(e.class) == "stackdriver"]
 }

--- a/modules/slo-pipeline/locals.tf
+++ b/modules/slo-pipeline/locals.tf
@@ -15,9 +15,9 @@
  */
 
 locals {
+  is_yaml          = length(regexall(".*yaml", var.exporters_path)) > 0
   exporters_tpl    = templatefile(var.exporters_path, var.exporters_vars)
-  exporters_map    = var.exporters_path.contains(".yaml") ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
-  exporters        = var.exporters_key != null ? exporters_map.key : exporters_map
+  exporters        = local.is_yaml ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
   bigquery_configs = [for e in local.exporters : e if lower(e.class) == "bigquery"]
   sd_configs       = [for e in local.exporters : e if lower(e.class) == "stackdriver"]
 }

--- a/modules/slo-pipeline/locals.tf
+++ b/modules/slo-pipeline/locals.tf
@@ -17,7 +17,8 @@
 locals {
   is_yaml          = length(regexall(".*yaml", var.exporters_path)) > 0
   exporters_tpl    = templatefile(var.exporters_path, var.exporters_vars)
-  exporters        = local.is_yaml ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
+  config_map       = local.is_yaml ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
+  exporters        = local.config_map.exporters
   bigquery_configs = [for e in local.exporters : e if lower(e.class) == "bigquery"]
   sd_configs       = [for e in local.exporters : e if lower(e.class) == "stackdriver"]
 }

--- a/modules/slo-pipeline/locals.tf
+++ b/modules/slo-pipeline/locals.tf
@@ -15,6 +15,9 @@
  */
 
 locals {
-  bigquery_configs = [for e in var.exporters : e if lower(e.class) == "bigquery"]
-  sd_configs       = [for e in var.exporters : e if lower(e.class) == "stackdriver"]
+  exporters_tpl    = templatefile(var.exporters_path, var.exporters_vars)
+  exporters_map    = var.exporters_path.contains(".yaml") ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
+  exporters        = var.exporters_key != null ? exporters_map.key : exporters_map
+  bigquery_configs = [for e in local.exporters : e if lower(e.class) == "bigquery"]
+  sd_configs       = [for e in local.exporters : e if lower(e.class) == "stackdriver"]
 }

--- a/modules/slo-pipeline/main.tf
+++ b/modules/slo-pipeline/main.tf
@@ -41,7 +41,7 @@ resource "local_file" "requirements_txt" {
 }
 
 resource "local_file" "exporters" {
-  content  = jsonencode(var.exporters)
+  content  = jsonencode(local.exporters)
   filename = "${path.module}/code/exporters.json"
 }
 

--- a/modules/slo-pipeline/outputs.tf
+++ b/modules/slo-pipeline/outputs.tf
@@ -21,7 +21,7 @@ output "project_id" {
 
 output "exporters" {
   description = "Exporter config"
-  value       = var.exporters
+  value       = local.exporters
 }
 
 output "function_name" {

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -18,18 +18,19 @@ variable "project_id" {
   description = "Project id to create SLO infrastructure"
 }
 
-variable "exporters" {
-  description = "SLO export destinations config"
-  type        = list(any)
+variable "exporters_path" {
+  description = "SLO exporters config file path"
+  type        = string
+}
 
-  # wait on https://github.com/hashicorp/terraform/issues/22449 to be merged
-  # type = list(object({
-  #   class = string
-  #   project_id = string
-  #   dataset_id = string
-  #   table_id = string
-  #   topic_name = string
-  # }))
+variable "exporters_vars" {
+  description = "Variables to dynamically replace in exporters config"
+  type        = map
+}
+
+variable "exporters_key" {
+  description = "Key in config to extract exporters from"
+  default     = null
 }
 
 variable "pubsub_topic_name" {
@@ -108,5 +109,5 @@ variable "dataset_create" {
 
 variable "slo_generator_version" {
   description = "SLO generator library version"
-  default     = "1.2.0"
+  default     = "1.3.0"
 }

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -105,5 +105,5 @@ variable "dataset_create" {
 
 variable "slo_generator_version" {
   description = "SLO generator library version"
-  default     = "1.3.0"
+  default     = "1.3.1"
 }

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -26,6 +26,7 @@ variable "exporters_path" {
 variable "exporters_vars" {
   description = "Variables to dynamically replace in exporters config"
   type        = map
+  default     = {}
 }
 
 variable "pubsub_topic_name" {

--- a/modules/slo-pipeline/variables.tf
+++ b/modules/slo-pipeline/variables.tf
@@ -28,11 +28,6 @@ variable "exporters_vars" {
   type        = map
 }
 
-variable "exporters_key" {
-  description = "Key in config to extract exporters from"
-  default     = null
-}
-
 variable "pubsub_topic_name" {
   description = "Pub/Sub topic name"
   default     = "slo-export-topic"

--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -49,11 +49,11 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | bucket\_force\_destroy | When deleting the GCS bucket containing the cloud function, delete all objects in the bucket first. | string | `"true"` | no |
 | config\_bucket | SLO generator GCS bucket to store configs. Create one if empty. | string | `""` | no |
 | config\_path | Path to SLO config | string | n/a | yes |
-| config\_vars | Variables to dynamically replace in SLO config | map | n/a | yes |
+| config\_vars | Variables to dynamically replace in SLO config | map | `<map>` | no |
 | environment\_variables | SLO generator env variables | map | `<map>` | no |
 | error\_budget\_policy\_path | Error budget policy path | string | n/a | yes |
 | exporters\_path | Path to SLO exporters | string | n/a | yes |
-| exporters\_vars | variables to dynamically replace in SLO exporters config | map | n/a | yes |
+| exporters\_vars | variables to dynamically replace in SLO exporters config | map | `<map>` | no |
 | extra\_files | Extra files to add to the Google Cloud Function code | object | `<list>` | no |
 | function\_environment\_variables | A set of key/value environment variable pairs to assign to the function. | map(string) | `<map>` | no |
 | function\_labels | A set of key/value label pairs to assign to the function. | map(string) | `<map>` | no |

--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -52,8 +52,6 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | config\_vars | Variables to dynamically replace in SLO config | map | `<map>` | no |
 | environment\_variables | SLO generator env variables | map | `<map>` | no |
 | error\_budget\_policy\_path | Error budget policy path | string | n/a | yes |
-| exporters\_path | Path to SLO exporters | string | n/a | yes |
-| exporters\_vars | variables to dynamically replace in SLO exporters config | map | `<map>` | no |
 | extra\_files | Extra files to add to the Google Cloud Function code | object | `<list>` | no |
 | function\_environment\_variables | A set of key/value environment variable pairs to assign to the function. | map(string) | `<map>` | no |
 | function\_labels | A set of key/value label pairs to assign to the function. | map(string) | `<map>` | no |

--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -47,10 +47,13 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | bucket\_force\_destroy | When deleting the GCS bucket containing the cloud function, delete all objects in the bucket first. | string | `"true"` | no |
-| config | SLO Configuration | object | n/a | yes |
 | config\_bucket | SLO generator GCS bucket to store configs. Create one if empty. | string | `""` | no |
+| config\_path | Path to SLO config | string | n/a | yes |
+| config\_vars | Variables to dynamically replace in SLO config | map | n/a | yes |
 | environment\_variables | SLO generator env variables | map | `<map>` | no |
-| error\_budget\_policy | Error budget policy config | object | `<list>` | no |
+| error\_budget\_policy\_path | Error budget policy path | string | n/a | yes |
+| exporters\_path | Path to SLO exporters | string | n/a | yes |
+| exporters\_vars | variables to dynamically replace in SLO exporters config | map | n/a | yes |
 | extra\_files | Extra files to add to the Google Cloud Function code | object | `<list>` | no |
 | function\_environment\_variables | A set of key/value environment variable pairs to assign to the function. | map(string) | `<map>` | no |
 | function\_labels | A set of key/value label pairs to assign to the function. | map(string) | `<map>` | no |
@@ -65,7 +68,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | schedule | Cron-like schedule for Cloud Scheduler | string | `"* * * * */1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Service account name (in case the generated one is too long) | string | `""` | no |
-| slo\_generator\_version | SLO generator library version | string | `"1.2.0"` | no |
+| slo\_generator\_version | SLO generator library version | string | `"1.3.0"` | no |
 | time\_zone | The timezone to use in scheduler | string | `"Etc/UTC"` | no |
 | use\_custom\_service\_account | Use a custom service account (pass service_account_email if true) | bool | `"false"` | no |
 | vpc\_connector | VPC Connector URI | string | `"null"` | no |

--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -68,7 +68,7 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 | schedule | Cron-like schedule for Cloud Scheduler | string | `"* * * * */1"` | no |
 | service\_account\_email | Service account email (optional) | string | `""` | no |
 | service\_account\_name | Service account name (in case the generated one is too long) | string | `""` | no |
-| slo\_generator\_version | SLO generator library version | string | `"1.3.0"` | no |
+| slo\_generator\_version | SLO generator library version | string | `"1.3.1"` | no |
 | time\_zone | The timezone to use in scheduler | string | `"Etc/UTC"` | no |
 | use\_custom\_service\_account | Use a custom service account (pass service_account_email if true) | bool | `"false"` | no |
 | vpc\_connector | VPC Connector URI | string | `"null"` | no |

--- a/modules/slo/gcs.tf
+++ b/modules/slo/gcs.tf
@@ -18,7 +18,6 @@ locals {
   slo_bucket_name         = var.config_bucket == "" ? google_storage_bucket.slos[0].name : var.config_bucket
   slo_config_url          = "gs://${local.slo_bucket_name}/${google_storage_bucket_object.slo_config.output_name}"
   error_budget_policy_url = "gs://${local.slo_bucket_name}/${google_storage_bucket_object.error_budget_policy.output_name}"
-  config_full             = merge(local.config, { exporters = local.exporters })
 }
 
 resource "google_storage_bucket" "slos" {
@@ -30,7 +29,7 @@ resource "google_storage_bucket" "slos" {
 
 resource "google_storage_bucket_object" "slo_config" {
   name    = "slos/${local.full_name}/slo_config.json"
-  content = jsonencode(local.config_full)
+  content = jsonencode(local.config)
   bucket  = local.slo_bucket_name
 }
 

--- a/modules/slo/gcs.tf
+++ b/modules/slo/gcs.tf
@@ -18,7 +18,7 @@ locals {
   slo_bucket_name         = var.config_bucket == "" ? google_storage_bucket.slos[0].name : var.config_bucket
   slo_config_url          = "gs://${local.slo_bucket_name}/${google_storage_bucket_object.slo_config.output_name}"
   error_budget_policy_url = "gs://${local.slo_bucket_name}/${google_storage_bucket_object.error_budget_policy.output_name}"
-  config_full             = merge(local.config, {exporters = local.exporters})
+  config_full             = merge(local.config, { exporters = local.exporters })
 }
 
 resource "google_storage_bucket" "slos" {

--- a/modules/slo/gcs.tf
+++ b/modules/slo/gcs.tf
@@ -24,7 +24,7 @@ locals {
 resource "google_storage_bucket" "slos" {
   count    = var.config_bucket == "" ? 1 : 0
   project  = var.project_id
-  name     = "${local.full_name}-conf"
+  name     = "${local.full_name}-${local.suffix}-conf"
   location = "EU"
 }
 

--- a/modules/slo/gcs.tf
+++ b/modules/slo/gcs.tf
@@ -29,12 +29,12 @@ resource "google_storage_bucket" "slos" {
 
 resource "google_storage_bucket_object" "slo_config" {
   name    = "slos/${local.full_name}/slo_config.json"
-  content = jsonencode(var.config)
+  content = jsonencode(local.config)
   bucket  = local.slo_bucket_name
 }
 
 resource "google_storage_bucket_object" "error_budget_policy" {
   name    = "slos/${local.full_name}/error_budget_policy.json"
-  content = jsonencode(var.error_budget_policy)
+  content = jsonencode(local.error_budget_policy)
   bucket  = local.slo_bucket_name
 }

--- a/modules/slo/gcs.tf
+++ b/modules/slo/gcs.tf
@@ -18,6 +18,7 @@ locals {
   slo_bucket_name         = var.config_bucket == "" ? google_storage_bucket.slos[0].name : var.config_bucket
   slo_config_url          = "gs://${local.slo_bucket_name}/${google_storage_bucket_object.slo_config.output_name}"
   error_budget_policy_url = "gs://${local.slo_bucket_name}/${google_storage_bucket_object.error_budget_policy.output_name}"
+  config_full             = merge(local.config, {exporters = local.exporters})
 }
 
 resource "google_storage_bucket" "slos" {
@@ -29,7 +30,7 @@ resource "google_storage_bucket" "slos" {
 
 resource "google_storage_bucket_object" "slo_config" {
   name    = "slos/${local.full_name}/slo_config.json"
-  content = jsonencode(local.config)
+  content = jsonencode(local.config_full)
   bucket  = local.slo_bucket_name
 }
 

--- a/modules/slo/iam.tf
+++ b/modules/slo/iam.tf
@@ -17,10 +17,10 @@
 locals {
   sa_name            = var.service_account_name != "" ? var.service_account_name : local.full_name
   sa_email           = length(google_service_account.main) > 0 ? google_service_account.main[0].email : var.service_account_email
-  ssm_class          = var.config.backend.class == "StackdriverServiceMonitoring"
-  ssm_project_id     = lookup(lookup(lookup(var.config.backend, "measurement", {}), "cluster_istio", {}), "project_id", "")
-  sd_class           = var.config.backend.class == "Stackdriver"
-  backend_project_id = lookup(var.config.backend, "project_id", null)
+  ssm_class          = local.config.backend.class == "StackdriverServiceMonitoring"
+  ssm_project_id     = lookup(lookup(lookup(local.config.backend, "measurement", {}), "cluster_istio", {}), "project_id", "")
+  sd_class           = local.config.backend.class == "Stackdriver"
+  backend_project_id = lookup(local.config.backend, "project_id", null)
 }
 
 resource "google_service_account" "main" {

--- a/modules/slo/locals.tf
+++ b/modules/slo/locals.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 locals {
   # Template rendering (JSON / YAML)
   is_yaml_config    = length(regexall(".*yaml", var.config_path)) > 0

--- a/modules/slo/locals.tf
+++ b/modules/slo/locals.tf
@@ -22,14 +22,17 @@ locals {
 
   # SLO config
   config_tpl = templatefile(var.config_path, var.config_vars)
-  config     = local.is_yaml_config ? yamldecode(local.config_tpl) : jsondecode(local.config_tpl)
+  config_map = local.is_yaml_config ? yamldecode(local.config_tpl) : jsondecode(local.config_tpl)
 
   # EBP config
   error_budget_policy_tpl = file(var.error_budget_policy_path)
   error_budget_policy     = local.is_yaml_ebp ? yamldecode(local.error_budget_policy_tpl) : jsondecode(local.error_budget_policy_tpl)
 
   # Exporters configs
-  exporters_tpl = templatefile(var.exporters_path, var.exporters_vars)
-  exporters_map = local.is_yaml_exporters ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
-  exporters     = local.exporters_map
+  exporters_tpl  = templatefile(var.exporters_path, var.exporters_vars)
+  exporters_list = local.is_yaml_exporters ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
+  exporters      = concat(tolist(lookup(local.config_map, "exporters", [])), local.exporters_list)
+
+  # Merge exporter in file with exporters in config
+  config = merge(local.config_map, {exporters=local.exporters})
 }

--- a/modules/slo/locals.tf
+++ b/modules/slo/locals.tf
@@ -30,9 +30,8 @@ locals {
 
   # Exporters configs
   exporters_tpl  = templatefile(var.exporters_path, var.exporters_vars)
-  exporters_list = local.is_yaml_exporters ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
-  exporters      = concat(tolist(lookup(local.config_map, "exporters", [])), local.exporters_list)
+  exporters_map = local.is_yaml_exporters ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
 
   # Merge exporter in file with exporters in config
-  config = merge(local.config_map, { exporters = local.exporters })
+  config = merge(local.config_map, local.exporters_map)
 }

--- a/modules/slo/locals.tf
+++ b/modules/slo/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  # Template rendering (JSON / YAML)
+  is_yaml_config            = length(regexall(".*yaml", var.config_path)) > 0
+  is_yaml_exporters         = length(regexall(".*yaml", var.exporters_path)) > 0
+  is_yaml_ebp               = length(regexall(".*yaml", var.error_budget_policy_path)) > 0
+  
+  # SLO config
+  config_tpl                = templatefile(var.config_path, var.config_vars)
+  config                    = local.is_yaml_config ? yamldecode(local.config_tpl) : jsondecode(local.config_tpl)
+
+  # EBP config
+  error_budget_policy_tpl   = file(var.error_budget_policy_path)
+  error_budget_policy       = local.is_yaml_ebp ? yamldecode(local.error_budget_policy_tpl) : jsondecode(local.error_budget_policy_tpl)
+
+  # Exporters configs
+  exporters_tpl             = templatefile(var.exporters_path, var.exporters_vars)
+  exporters_map             = local.is_yaml_exporters ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
+  exporters                 = local.exporters_map
+}

--- a/modules/slo/locals.tf
+++ b/modules/slo/locals.tf
@@ -1,19 +1,19 @@
 locals {
   # Template rendering (JSON / YAML)
-  is_yaml_config            = length(regexall(".*yaml", var.config_path)) > 0
-  is_yaml_exporters         = length(regexall(".*yaml", var.exporters_path)) > 0
-  is_yaml_ebp               = length(regexall(".*yaml", var.error_budget_policy_path)) > 0
-  
+  is_yaml_config    = length(regexall(".*yaml", var.config_path)) > 0
+  is_yaml_exporters = length(regexall(".*yaml", var.exporters_path)) > 0
+  is_yaml_ebp       = length(regexall(".*yaml", var.error_budget_policy_path)) > 0
+
   # SLO config
-  config_tpl                = templatefile(var.config_path, var.config_vars)
-  config                    = local.is_yaml_config ? yamldecode(local.config_tpl) : jsondecode(local.config_tpl)
+  config_tpl = templatefile(var.config_path, var.config_vars)
+  config     = local.is_yaml_config ? yamldecode(local.config_tpl) : jsondecode(local.config_tpl)
 
   # EBP config
-  error_budget_policy_tpl   = file(var.error_budget_policy_path)
-  error_budget_policy       = local.is_yaml_ebp ? yamldecode(local.error_budget_policy_tpl) : jsondecode(local.error_budget_policy_tpl)
+  error_budget_policy_tpl = file(var.error_budget_policy_path)
+  error_budget_policy     = local.is_yaml_ebp ? yamldecode(local.error_budget_policy_tpl) : jsondecode(local.error_budget_policy_tpl)
 
   # Exporters configs
-  exporters_tpl             = templatefile(var.exporters_path, var.exporters_vars)
-  exporters_map             = local.is_yaml_exporters ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
-  exporters                 = local.exporters_map
+  exporters_tpl = templatefile(var.exporters_path, var.exporters_vars)
+  exporters_map = local.is_yaml_exporters ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
+  exporters     = local.exporters_map
 }

--- a/modules/slo/locals.tf
+++ b/modules/slo/locals.tf
@@ -17,21 +17,13 @@
 locals {
   # Template rendering (JSON / YAML)
   is_yaml_config    = length(regexall(".*yaml", var.config_path)) > 0
-  is_yaml_exporters = length(regexall(".*yaml", var.exporters_path)) > 0
   is_yaml_ebp       = length(regexall(".*yaml", var.error_budget_policy_path)) > 0
 
   # SLO config
   config_tpl = templatefile(var.config_path, var.config_vars)
-  config_map = local.is_yaml_config ? yamldecode(local.config_tpl) : jsondecode(local.config_tpl)
+  config     = local.is_yaml_config ? yamldecode(local.config_tpl) : jsondecode(local.config_tpl)
 
   # EBP config
   error_budget_policy_tpl = file(var.error_budget_policy_path)
   error_budget_policy     = local.is_yaml_ebp ? yamldecode(local.error_budget_policy_tpl) : jsondecode(local.error_budget_policy_tpl)
-
-  # Exporters configs
-  exporters_tpl  = templatefile(var.exporters_path, var.exporters_vars)
-  exporters_map = local.is_yaml_exporters ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
-
-  # Merge exporter in file with exporters in config
-  config = merge(local.config_map, local.exporters_map)
 }

--- a/modules/slo/locals.tf
+++ b/modules/slo/locals.tf
@@ -34,5 +34,5 @@ locals {
   exporters      = concat(tolist(lookup(local.config_map, "exporters", [])), local.exporters_list)
 
   # Merge exporter in file with exporters in config
-  config = merge(local.config_map, {exporters=local.exporters})
+  config = merge(local.config_map, { exporters = local.exporters })
 }

--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   full_name                 = "slo-${local.config.service_name}-${local.config.feature_name}-${local.config.slo_name}"
-  pubsub_configs            = [for e in local.exporters : e if lower(e.class) == "pubsub"]
+  pubsub_configs            = [for e in local.config.exporters : e if lower(e.class) == "pubsub"]
   function_source_directory = var.function_source_directory != "" ? var.function_source_directory : "${path.module}/code"
   suffix                    = random_id.suffix.hex
   requirements_txt = templatefile(

--- a/modules/slo/main.tf
+++ b/modules/slo/main.tf
@@ -15,22 +15,10 @@
  */
 
 locals {
-  # Template rendering
-  config_tpl                = templatefile(var.config_path, var.config_vars)
-  config                    = local.config_tpl.contains(".yaml") ? yamldecode(local.config_tpl) : jsondecode(local.config_tpl)
-  error_budget_policy_tpl   = file(var.error_budget_policy_path)
-  error_budget_policy       = var.error_budget_policy_path.contains(".yaml") ? yamldecode(local.error_budget_policy_tpl) : jsondecode(local.error_budget_policy_tpl)
-  exporters_tpl             = templatefile(var.exporters_path, var.exporters_vars)
-  exporters_map             = var.exporters_path.contains(".yaml") ? yamldecode(local.exporters_tpl) : jsondecode(local.exporters_tpl)
-  exporters                 = var.exporters_key != null ? exporters_map.key : exporters_map
-
-  # Other vars
   full_name                 = "slo-${local.config.service_name}-${local.config.feature_name}-${local.config.slo_name}"
-  pubsub_configs            = [for e in local.config.exporters : e if lower(e.class) == "pubsub"]
+  pubsub_configs            = [for e in local.exporters : e if lower(e.class) == "pubsub"]
   function_source_directory = var.function_source_directory != "" ? var.function_source_directory : "${path.module}/code"
   suffix                    = random_id.suffix.hex
-  
-  # Cloud function files
   requirements_txt = templatefile(
     "${path.module}/code/requirements.txt.tpl", {
       slo_generator_version = var.slo_generator_version

--- a/modules/slo/outputs.tf
+++ b/modules/slo/outputs.tf
@@ -21,7 +21,7 @@ output "project_id" {
 
 output "config" {
   description = "SLO Config"
-  value       = var.config
+  value       = local.config
 }
 
 output "service_account_email" {

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -78,17 +78,6 @@ variable "config_vars" {
   default     = {}
 }
 
-variable "exporters_path" {
-  description = "Path to SLO exporters"
-  type        = string
-}
-
-variable "exporters_vars" {
-  description = "variables to dynamically replace in SLO exporters config"
-  type        = map
-  default     = {}
-}
-
 variable "error_budget_policy_path" {
   description = "Error budget policy path"
   type        = string

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -87,11 +87,6 @@ variable "exporters_vars" {
   type        = map
 }
 
-variable "exporters_key" {
-  description = "Key in config to extract exporters from"
-  default     = null
-}
-
 variable "error_budget_policy_path" {
   description = "Error budget policy path"
   type        = string

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -75,6 +75,7 @@ variable "config_path" {
 variable "config_vars" {
   description = "Variables to dynamically replace in SLO config"
   type        = map
+  default     = {}
 }
 
 variable "exporters_path" {
@@ -85,6 +86,7 @@ variable "exporters_path" {
 variable "exporters_vars" {
   description = "variables to dynamically replace in SLO exporters config"
   type        = map
+  default     = {}
 }
 
 variable "error_budget_policy_path" {

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -35,7 +35,7 @@ variable "labels" {
 
 variable "slo_generator_version" {
   description = "SLO generator library version"
-  default     = "1.3.0"
+  default     = "1.3.1"
 }
 
 variable "extra_files" {

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -35,7 +35,7 @@ variable "labels" {
 
 variable "slo_generator_version" {
   description = "SLO generator library version"
-  default     = "1.2.0"
+  default     = "1.3.0"
 }
 
 variable "extra_files" {
@@ -67,78 +67,34 @@ variable "environment_variables" {
   default     = {}
 }
 
-variable "config" {
-  description = "SLO Configuration"
-  type = object({
-    slo_name        = string
-    slo_target      = number
-    slo_description = string
-    service_name    = string
-    feature_name    = string
-    backend         = any
-    # wait on https://github.com/hashicorp/terraform/issues/19898 to get a
-    # resolution
-    # backend = object({
-    #   class       = string
-    #   method      = string
-    #   measurement = map(any)
-    # })
-    exporters = list(any)
-    # wait on https://github.com/hashicorp/terraform/issues/22449 to be merged
-    # type = list(object({
-    #   class = string
-    #   project_id = string
-    #   dataset_id = string
-    #   table_id = string
-    #   topic_name = string
-    # }))
-  })
+variable "config_path" {
+  description = "Path to SLO config"
+  type        = string
 }
 
-variable "error_budget_policy" {
-  description = "Error budget policy config"
-  type = list(object({
-    error_budget_policy_step_name  = string
-    measurement_window_seconds     = number
-    alerting_burn_rate_threshold   = number
-    urgent_notification            = bool
-    overburned_consequence_message = string
-    achieved_consequence_message   = string
-  }))
-  default = [
-    {
-      error_budget_policy_step_name  = "a.Last 1 hour",
-      measurement_window_seconds     = 3600,
-      alerting_burn_rate_threshold   = 9,
-      urgent_notification            = true,
-      overburned_consequence_message = "Page the SRE team to defend the SLO",
-      achieved_consequence_message   = "Last hour on track"
-    },
-    {
-      error_budget_policy_step_name  = "b.Last 12 hours",
-      measurement_window_seconds     = 43200,
-      alerting_burn_rate_threshold   = 3,
-      urgent_notification            = true,
-      overburned_consequence_message = "Page the SRE team to defend the SLO",
-      achieved_consequence_message   = "Last 12 hours on track"
-    },
-    {
-      error_budget_policy_step_name  = "c.Last 7 days",
-      measurement_window_seconds     = 604800,
-      alerting_burn_rate_threshold   = 1.5,
-      urgent_notification            = false,
-      overburned_consequence_message = "Dev team dedicates two Engineers to the action items of the post-mortem",
-      achieved_consequence_message   = "Last week on track"
-    },
-    {
-      error_budget_policy_step_name  = "d.Last 28 days",
-      measurement_window_seconds     = 2419200,
-      alerting_burn_rate_threshold   = 1,
-      urgent_notification            = false,
-      overburned_consequence_message = "Freeze release, unless related to reliability or security",
-      achieved_consequence_message   = "Unfreeze release, per the agreed roll-out policy"
-    }
-  ]
+variable "config_vars" {
+  description = "Variables to dynamically replace in SLO config"
+  type        = map
+}
+
+variable "exporters_path" {
+  description = "Path to SLO exporters"
+  type        = string
+}
+
+variable "exporters_vars" {
+  description = "variables to dynamically replace in SLO exporters config"
+  type        = map
+}
+
+variable "exporters_key" {
+  description = "Key in config to extract exporters from"
+  default     = null
+}
+
+variable "error_budget_policy_path" {
+  description = "Error budget policy path"
+  type        = string
 }
 
 variable "use_custom_service_account" {


### PR DESCRIPTION
Pass SLO configs and Error Budget Policy file paths instead of content to go around TF variable limitation.
Because of #55 (cannot have complex variables), the module has to take in config file paths instead of decoded configs to support the latest added attribute `metrics`.

Also adds:
* Custom backends / exporters (dynamic loading) supported in v1.3.x
* Variable replacements within the module to simplify end user configs

This will also help with updates to the SLO config or error budget policy JSON schemas without needing to update the Terraform module inputs.

Fix #55 
Fix #57 