### PR TITLE
fix: GCS improvements

### DIFF
--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -48,7 +48,8 @@ See the [fixture project](../../test/setup/main.tf) for an example to create thi
 |------|-------------|:----:|:-----:|:-----:|
 | bucket\_force\_destroy | When deleting the GCS bucket containing the cloud function, delete all objects in the bucket first. | string | `"true"` | no |
 | config | SLO Configuration | object | n/a | yes |
-| config\_bucket | SLO generator GCS bucket to store configs. Create one if empty. | string | `""` | no |
+| config\_bucket | SLO generator GCS bucket to store configs and GCF code. | string | `""` | no |
+| config\_bucket\_region | Config bucket region | string | `"EU"` | no |
 | environment\_variables | SLO generator env variables | map | `<map>` | no |
 | error\_budget\_policy | Error budget policy config | object | `<list>` | no |
 | extra\_files | Extra files to add to the Google Cloud Function code | object | `<list>` | no |

--- a/modules/slo/gcs.tf
+++ b/modules/slo/gcs.tf
@@ -21,10 +21,12 @@ locals {
 }
 
 resource "google_storage_bucket" "slos" {
-  count    = var.config_bucket == "" ? 1 : 0
-  project  = var.project_id
-  name     = "${local.full_name}-conf"
-  location = "EU"
+  count         = var.config_bucket == "" ? 1 : 0
+  project       = var.project_id
+  name          = "${local.full_name}-${local.suffix}-conf"
+  location      = var.config_bucket_region
+  force_destroy = true
+  labels        = var.labels
 }
 
 resource "google_storage_bucket_object" "slo_config" {

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -48,8 +48,13 @@ variable "extra_files" {
 }
 
 variable "config_bucket" {
-  description = "SLO generator GCS bucket to store configs. Create one if empty."
-  default     = ""
+  description = "SLO generator GCS bucket to store configs and GCF code."
+  default     = "" # create one
+}
+
+variable "config_bucket_region" {
+  description = "Config bucket region"
+  default     = "EU"
 }
 
 variable "vpc_connector" {


### PR DESCRIPTION
This PR:
- [x] Adds a suffix to GCS bucket to make it unique (name can conflict sometimes when recreating / updating the module)
- [x] Add force_destroy set to `true` for SLO configs: those are ephemeral so they can be destroyed safely
- [x] Add `config_bucket_region` variable to be able to set GCS region (default to "EU")