### PR TITLE
feat!: metadata labels

### DIFF
--- a/examples/slo-generator/simple_example/main.tf
+++ b/examples/slo-generator/simple_example/main.tf
@@ -54,6 +54,7 @@ module "slo" {
     slo_description = "Acked Pub/Sub messages over total number of Pub/Sub messages"
     service_name    = "svc"
     feature_name    = "pubsub"
+    metadata        = {}
     backend = {
       class      = "Stackdriver"
       method     = "good_bad_ratio"

--- a/examples/slo-generator/yaml_example/templates/slo_bq_latency.yaml
+++ b/examples/slo-generator/yaml_example/templates/slo_bq_latency.yaml
@@ -18,6 +18,8 @@ slo_description: >
   99% of BigQuery API HTTP response latencies < 400ms
 slo_name:        latency
 slo_target:      0.99
+metadata:
+  env:           test
 backend:
   class:         Stackdriver
   project_id:    "${stackdriver_host_project_id}"

--- a/examples/slo-generator/yaml_example/templates/slo_gcf_errors.yaml
+++ b/examples/slo-generator/yaml_example/templates/slo_gcf_errors.yaml
@@ -17,6 +17,8 @@ feature_name:    gcf
 slo_description: Less than 0.01% of errors in Cloud Functions logs
 slo_name:        errors
 slo_target:      0.99
+metadata:
+  env:           test
 backend:
   class:         Stackdriver
   project_id:    "${stackdriver_host_project_id}"

--- a/examples/slo-generator/yaml_example/templates/slo_pubsub_ack.yaml
+++ b/examples/slo-generator/yaml_example/templates/slo_pubsub_ack.yaml
@@ -17,6 +17,8 @@ feature_name:    pubsub
 slo_description: 99% of outstanding PubSub messages are acknowledged
 slo_name:        ack
 slo_target:      0.99
+metadata:
+  env:           test
 backend:
   class:         Stackdriver
   project_id:    "${stackdriver_host_project_id}"

--- a/modules/slo/variables.tf
+++ b/modules/slo/variables.tf
@@ -75,6 +75,7 @@ variable "config" {
     slo_description = string
     service_name    = string
     feature_name    = string
+    metadata        = map(string)
     backend         = any
     exporters       = any
   })


### PR DESCRIPTION
This PR supports metadata labels in SLO configs.
Since Terraform doesn't support optional variables, this is a breaking change.
Action to take:
**Add `metadata` field to SLO configs**