### PR TITLE
add ability to disable logs-writer iam

### DIFF
--- a/modules/slo/iam.tf
+++ b/modules/slo/iam.tf
@@ -52,6 +52,7 @@ resource "google_project_iam_member" "stackdriver-ssm-svc-viewer" {
 }
 
 resource "google_project_iam_member" "logs-writer" {
+  count   = var.grant_iam_roles ? 1 : 0
   project = var.project_id
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${local.sa_email}"


### PR DESCRIPTION
Currently, when using foreach to create our SLOs. We elected to disable the modules granting of IAM roles to prevent it from doing the same action over and over with the same custom service account.

The logs writer role is not able to be prevented causing duplicate resources to be made.

```module.slo-istio["*-prod-us-1-uscen1-gke-main-cluster-ai-r*-prod-us-1-uscen1-avail"].google_project_iam_member.logs-writer: Still creating... [10s elapsed]

module.slo-istio["*-prod-us-2-useas1-gke-main-cluster-domain*-prod-us-2-useas1-avail"].google_project_iam_member.logs-writer: Still creating... [10s elapsed]

module.slo-istio["*-prod-us-2-useas1-gke-main-cluster-ai-a*-prod-us-2-useas1-avail"].google_project_iam_member.logs-writer: Still creating... [10s elapsed]

module.slo-istio["*-prod-us-1-useas1-gke-main-cluster-voic*-prod-us-1-useas1-avail"].google_project_iam_member.logs-writer: Still creating... [20s elapsed]```