### PR TITLE
fix: Ignore "run.googleapis.com/operation-id" annotation in Cloud Run

### DIFF
--- a/modules/slo-generator/main.tf
+++ b/modules/slo-generator/main.tf
@@ -80,6 +80,12 @@ resource "google_cloud_run_service" "service" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations,
+    ]
+  }
+
   template {
     metadata {
       annotations = merge(local.default_annotations, var.annotations)


### PR DESCRIPTION
As mentioned in the [docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service#annotations), the Cloud Run API can add additional annotations that were not provided in the Terraform configuration. The "run.googleapis.com/operation-id" annotation causes unnecessary changes, so this PR adds the `lifecycle.ignore_changes` rule to the `metadata.0.annotations` field.

Tests with `make docker_test_integration` ran successful.