### PR TITLE
feat: add timeout_seconds as configurable parameters

### DIFF
--- a/modules/slo-generator/main.tf
+++ b/modules/slo-generator/main.tf
@@ -124,6 +124,7 @@ resource "google_cloud_run_service" "service" {
           limits   = var.limits
         }
       }
+      timeout_seconds = var.timeout_seconds
     }
   }
 

--- a/modules/slo-generator/variables.tf
+++ b/modules/slo-generator/variables.tf
@@ -81,6 +81,11 @@ variable "concurrency" {
   default     = 80
 }
 
+variable "timeout_seconds" {
+  description = "Cloud Run service TimeoutSeconds holds the max duration the instance is allowed for responding to a request."
+  default     = 300
+}
+
 variable "bucket_name" {
   description = "slo-generator GCS bucket name"
   default     = ""


### PR DESCRIPTION
To be able to configure a custom timeout in second the Cloud Run service